### PR TITLE
Fix reputation sync (3.0.x)

### DIFF
--- a/root/includes/acp/acp_reputation.php
+++ b/root/includes/acp/acp_reputation.php
@@ -311,8 +311,8 @@ class acp_reputation
 								$sql = 'SELECT SUM(point) AS total_points, rep_to
 									FROM ' . REPUTATIONS_TABLE . '
 									WHERE action != 5
-										AND rep_to >= ' . ($start + 1) . '
-										AND rep_to <= ' . ($start + $this->step) . '
+										AND rep_id >= ' . ($start + 1) . '
+										AND rep_id <= ' . ($start + $this->step) . '
 									GROUP BY rep_to';
 								$result = $db->sql_query($sql);
 


### PR DESCRIPTION
Step 6 is supposed to use rep_id as reference for processing chunk size, since it uses max rep_id for loop control. rep_to may refer to user ID that exceeds rep_id, thus some users will left unprocessed.